### PR TITLE
Fix wrong Gradle properties: group, version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 kotlin.code.style=official
 
-group="com.jongmin.oss"
-version="0.0.1-SNAPSHOT"
+group=com.jongmin.oss
+version=0.0.1-SNAPSHOT
 
 org.gradle.parallel=true
 org.gradle.jvmargs=-Xmx2g


### PR DESCRIPTION
# Motivation

The task `assemble` failed with the following message:

>  Could not create ZIP 'D:\workspace\spring-boot-starter-upbit\client\retrofit\spring\boot\build\libs\boot-"0.0.1-SNAPSHOT".jar'.


# Problem

Double quotes characters are used as a part of properties now.


# Modifications

- Pill off the double quotation marks in `gradle.properties`
    + group
    + version