### PR TITLE
Replace io.spring.dependency-management with Gradle plaform feature

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,18 +1,9 @@
-import com.linecorp.support.project.multi.recipe.configure
 import com.linecorp.support.project.multi.recipe.configureByTypeHaving
 import com.linecorp.support.project.multi.recipe.configureByTypePrefix
 import com.linecorp.support.project.multi.recipe.configureByTypeSuffix
-import com.linecorp.support.project.multi.recipe.matcher.ProjectMatchers.Companion.byTypeHaving
-import com.linecorp.support.project.multi.recipe.matcher.ProjectMatchers.Companion.byTypeSuffix
-import com.linecorp.support.project.multi.recipe.matcher.and
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
-import org.springframework.boot.gradle.tasks.bundling.BootJar
-import org.springframework.boot.gradle.tasks.run.BootRun
-
 plugins {
-    id("org.springframework.boot") version "2.5.4" apply false
-    id("io.spring.dependency-management") version "1.0.11.RELEASE" apply false
     kotlin("jvm") version "1.5.10"
     kotlin("kapt") version "1.5.21"
     kotlin("plugin.spring") version "1.4.21" apply false
@@ -41,24 +32,25 @@ configureByTypePrefix("kotlin") {
     }
 
     dependencies {
+        api(platform("org.springframework.boot:spring-boot-dependencies:2.5.4"))
+
         api("org.jetbrains.kotlin:kotlin-reflect")
         api("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
 
         testImplementation(kotlin("test"))
         testImplementation("org.mockito.kotlin:mockito-kotlin:3.2.0")
-        testImplementation("org.assertj:assertj-core:3.20.2")
+        testImplementation("org.assertj:assertj-core")
     }
 }
 
 configureByTypeHaving("boot") {
-    apply(plugin = "org.springframework.boot")
-    apply(plugin = "io.spring.dependency-management")
     apply(plugin = "kotlin-spring")
 
     dependencies {
+        annotationProcessor("org.springframework.boot:spring-boot-autoconfigure-processor:2.5.4")
+
         implementation("org.springframework.boot:spring-boot")
         implementation("org.springframework.boot:spring-boot-autoconfigure")
-        annotationProcessor("org.springframework.boot:spring-boot-autoconfigure-processor")
 
         testImplementation("org.springframework.boot:spring-boot-starter-test")
     }
@@ -66,20 +58,4 @@ configureByTypeHaving("boot") {
 
 configureByTypeSuffix("lib") {
     apply(plugin = "java-library")
-}
-
-configure(byTypeHaving("boot") and byTypeSuffix("lib")) {
-    tasks {
-        withType<Jar> {
-            enabled = true
-        }
-
-        withType<BootJar> {
-            enabled = false
-        }
-
-        withType<BootRun> {
-            enabled = false
-        }
-    }
 }


### PR DESCRIPTION
# Motivation

Though there is no Spring Boot application yet,
the plugins, `org.springframework.boot` and `io.spring.dependency-management`, are used only for applying Spring Boot BOM.
And, those make some pitfalls related to the Gradle tasks: `jar`, `bootJar`, `bootRun`.

I think it'd better introduce the Gradle plugin for Spring Boot when required later.

# Modifications

- Remove the Gradle plugin not required yet: `org.springframework.boot`
- Replace the Gradle plugin `io.spring.dependency-management` with Grade platform feature.