### PR TITLE
Declare BOM once

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,6 +33,11 @@ configureByTypePrefix("kotlin") {
         api(platform("org.springframework.boot:spring-boot-dependencies:2.5.4"))
         api(platform("org.jetbrains.kotlin:kotlin-bom:1.5.30"))
         api(platform("org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.5.2"))
+        api(platform("com.linecorp.armeria:armeria-bom:1.11.0"))
+        listOf("retrofit", "converter-jackson").forEach {
+            api(platform("com.squareup.retrofit2:$it:2.9.0"))
+        }
+
 
         api("org.jetbrains.kotlin:kotlin-reflect")
         api("org.jetbrains.kotlin:kotlin-stdlib-jdk8")

--- a/client/retrofit/build.gradle.kts
+++ b/client/retrofit/build.gradle.kts
@@ -3,13 +3,12 @@ dependencies {
     api(project(":token"))
 
     // retrofit
-    implementation("com.squareup.retrofit2:retrofit:2.9.0")
-    implementation("com.squareup.retrofit2:converter-jackson:2.9.0")
+    implementation("com.squareup.retrofit2:retrofit")
+    implementation("com.squareup.retrofit2:converter-jackson")
 
     // jackson
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.12.4")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 
     // armeria
-    implementation(platform("com.linecorp.armeria:armeria-bom:1.10.0"))
     implementation("com.linecorp.armeria:armeria-retrofit2")
 }

--- a/client/retrofit/spring/boot/autoconfigure/build.gradle.kts
+++ b/client/retrofit/spring/boot/autoconfigure/build.gradle.kts
@@ -31,13 +31,12 @@ dependencies {
     implementation(project(":client:retrofit"))
 
     // retrofit
-    implementation("com.squareup.retrofit2:retrofit:2.9.0")
+    implementation("com.squareup.retrofit2:retrofit")
 
     // jackson
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.12.4")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 
     // armeria
-    implementation(platform("com.linecorp.armeria:armeria-bom:1.10.0"))
     implementation("com.linecorp.armeria:armeria-retrofit2")
 
     "integrationTestImplementation"(mockServerProject)


### PR DESCRIPTION
# Modifications

`armeria-bom` is declared both in `:client:retrofit` and `:client:retrofit:spring:boot:autoconfigure`.
In the mono-repo approach, it can be good to manage dependencies' versions once.