### PR TITLE
Set the same JVM version for Java target compatibility

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,6 +19,10 @@ allprojects {
 configureByTypePrefix("kotlin") {
     apply(plugin = "org.jetbrains.kotlin.jvm")
 
+    java {
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
+
     tasks {
         withType<KotlinCompile> {
             kotlinOptions.jvmTarget = "1.8"


### PR DESCRIPTION
# Modifications

> 'compileJava' task (current target is 11) and 'compileKotlin' task (current target is 1.8) jvm target compatibility should be set to the same Java version.

I'm sorry. 😭 